### PR TITLE
スマホ向けの変更で崩れた部分の対応

### DIFF
--- a/nico-rekari-comment-panel.user.js
+++ b/nico-rekari-comment-panel.user.js
@@ -268,7 +268,7 @@
     elmColLeft.setAttribute("style", "display: flex;flex-direction: column;gap: 12px;");
     elmColContainer.appendChild(elmColLeft);
     const elmColRight = document.createElement("div");
-    elmColRight.setAttribute("style", "flex: 1 1 auto; position: relative;");
+    elmColRight.setAttribute("style", "position: relative;");
     elmColContainer.appendChild(elmColRight);
 
     elmPlayer.setAttribute("style", "margin-left: 0; margin-right: 0; border-radius: 12px; width: 100%");

--- a/nico-rekari-comment-panel.user.js
+++ b/nico-rekari-comment-panel.user.js
@@ -259,7 +259,7 @@
       setTimeout(appendCommentList, 250);
       return;
     }
-    elmPage.setAttribute("style", elmPage.getAttribute("style") + ";--max-player-width: 1200px;");
+    elmPage.setAttribute("style", elmPage.getAttribute("style") + ";--max-player-width: 1200px; width: auto; max-width: unset;");
 
     const elmColContainer = document.createElement("div");
     elmColContainer.setAttribute("style", "display: grid; grid-template-columns: 2fr 1fr; gap: 12px;");

--- a/nico-rekari-comment-panel.user.js
+++ b/nico-rekari-comment-panel.user.js
@@ -278,7 +278,7 @@
     const elmPlayerCloned = elmPlayer.cloneNode(false);
 
     const inputContainer = elmCommentInput.children[0];
-    inputContainer.setAttribute("style", "display: grid; grid-template-columns: 1fr 3fr 1fr;");
+    inputContainer.setAttribute("style", "display: grid; grid-template-columns: 1fr 3fr 1fr; grid-auto-rows: 40px;");
 
     const controlContainer = elmPlayer.children[2];
     controlContainer.setAttribute("style", "gap: 10px;");

--- a/nico-rekari-comment-panel.user.js
+++ b/nico-rekari-comment-panel.user.js
@@ -271,6 +271,8 @@
     elmColRight.setAttribute("style", "flex: 1 1 auto; position: relative;");
     elmColContainer.appendChild(elmColRight);
 
+    elmPlayer.setAttribute("style", "margin-left: 0; margin-right: 0; border-radius: 12px; width: 100%");
+
     // コメント投稿時に挿入される Cloudflare Turnstile 用 iframe は
     // elmPlayer の要素位置を基準にしているようなので、元の要素は残しておく
     const elmPlayerCloned = elmPlayer.cloneNode(false);


### PR DESCRIPTION
ニコニコのスマホ向けの変更で、windowが小さいときにstyleが崩れることへの対応をしています。

変更前
![Screenshot 2024-06-18 at 22-36-25 バレンタインなので俺の嫁に「メルト」のベースを弾かせてみた - ニコニコ動画](https://github.com/inonote/nico-rekari-comment-panel-userscript/assets/47109823/d939611a-b4bb-4868-8573-1911cf15a04b)

変更後
![Screenshot 2024-06-18 at 23-50-07 バレンタインなので俺の嫁に「メルト」のベースを弾かせてみた - ニコニコ動画](https://github.com/inonote/nico-rekari-comment-panel-userscript/assets/47109823/b036ca41-df83-424a-b871-1690838bffcb)

これは取り敢えずwindowサイズ変更による変化が無くなるように調整しています。
「縮小営業中」まわりの文字サイズも変化していますが、このスクリプトの役目ではないと考えたので触れていません。

その他の変更も含みます。

- 意味を成していなかったstyleの削除を行いました。
  - 見逃していたものです。これは以前にやっておくべきでした。
- windowが小さいときに作られる、コメント一覧と動画横の大きな余白の削除を行いました。
  - コメント一覧と動画両方の見易さのための変更です。
